### PR TITLE
Fix package.yaml file

### DIFF
--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -8,7 +8,7 @@ dependencies:
   m5stack_core2:
     url: github.com/toitware/toit-m5stack-core2
     version: ^1.1.0
-  mpu6886:
+  ft63xx:
     path: ..
   pixel_display:
     url: github.com/toitware/toit-pixel-display


### PR DESCRIPTION
The lock file already correctly added the `ft63xx` import, but the yaml file didn't.